### PR TITLE
Remove tracking parameters from WalletMonero link

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -191,7 +191,7 @@
     - name: Tuxcon Hosting - Mail and Web Hosting
       url: https://tuxcon.com
     - name: WalletMonero - Online Wallet
-      url: https://walletmonero.com?utm_source=getmonero_org&utm_medium=list&utm_content=monero_list&utm_campaign=getmonero_org
+      url: https://walletmonero.com
     - name: Web Developer - Python with Django web framework
       url: http://www.voteforrodneylewis.com
     - name: Web Developer - Stefanos


### PR DESCRIPTION
Given the changes people have made to improve the privacy of users on the site (#400, #442), it seems a bit silly to leave tracking codes in links.